### PR TITLE
feat: expose dict_type and tier on the Dictionary API model

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -396,6 +396,8 @@ class Dictionary(BaseModel):
     id: int
     name_arabic: str
     wikidata_id: str | None = None
+    dict_type: str | None = None
+    tier: int | None = None
 
 
 class DictionariesResponse(BaseModel):


### PR DESCRIPTION
## Summary
- `arabterm` is adding `dict_type` (terminology/language/thesaurus) and `tier` (1-5 reliability ranking) columns to `dictionary` (forzagreen/arabterm#32), for use in future search ranking work.
- `/api/v1/dicts` already returns these via `SELECT * FROM dictionary` + the `Dictionary` model's `extra="allow"`, so no behavior changes here. This just promotes both to explicit, documented fields on the response model — the same treatment `wikidata_id` already gets — so they show up properly typed in the OpenAPI docs.
- Both fields default to `None`, so this is safe to merge before the underlying MariaDB dump actually has the data (the cross-repo dump refresh is a separate automated PR).

## Test plan
- [x] `uv run pytest backend/tests/test_app.py` — 13 passed
- [x] `uv run ruff check` / `ruff format --check` — clean