### PR TITLE
Rank exact term matches first, merge separator-packed translations

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -278,6 +278,67 @@ def normalise_french(text: str) -> str:
     return text
 
 
+# Separator characters this dataset uses to pack multiple synonymous
+# translations into a single field: ';', '/', and the Arabic '،' / '؛'.
+# Deliberately excludes the plain ',' -- entries also use it for headword
+# inversion ("profile, hydraulic") and gender/POS annotations
+# ("vitesse commerciale, f"), so splitting on it would fabricate bogus terms.
+SEPARATOR_RE = re.compile(r"[;/،؛]")
+
+
+def split_translations(value: str) -> list[str]:
+    """Split a field that may pack multiple synonymous translations into its
+    individual parts (see SEPARATOR_RE), trimming incidental whitespace."""
+    return [part.strip() for part in SEPARATOR_RE.split(value) if part.strip()]
+
+
+def _strip_query_quotes(query: str) -> str:
+    # The frontend and gadget both send q=`"${term}"` (literal quotes) as a
+    # leftover phrase-search hint; MariaDB's NATURAL LANGUAGE MODE ignores
+    # them, but our own exact-match comparison needs the bare term.
+    query = query.strip()
+    if len(query) >= 2 and query[0] == query[-1] == '"':
+        query = query[1:-1].strip()
+    return query
+
+
+def query_matches_term(term: dict, query: str) -> bool:
+    """True when `query` exactly matches one of the term's translations.
+
+    Compares against every part of a multi-translation field (see
+    split_translations), not just the field as a whole, so a query like
+    "telescope" matches a term whose english is "reflecting telescope"
+    only if "telescope" is itself one of the listed synonyms.
+    """
+    query = _strip_query_quotes(query)
+    if not query:
+        return False
+
+    arabic = term.get("arabic")
+    if arabic:
+        query_ar = normalise_arabic(query)
+        if query_ar and any(
+            normalise_arabic(part) == query_ar for part in split_translations(arabic)
+        ):
+            return True
+
+    for field, normaliser in (
+        ("english", normalise_english),
+        ("french", normalise_french),
+    ):
+        value = term.get(field)
+        if not value:
+            continue
+        query_norm = normaliser(query).casefold()
+        if query_norm and any(
+            normaliser(part).casefold() == query_norm
+            for part in split_translations(value)
+        ):
+            return True
+
+    return False
+
+
 # Display/ranking order for dictionary types within a result group.
 # Anything missing or not in this map (e.g. not-yet-classified dictionaries)
 # sorts after all known types.
@@ -294,20 +355,56 @@ def occurrence_sort_key(term: dict):
     return (type_priority, tier_priority, term.get("dictionary_wikidata_id") is None)
 
 
-def aggregate_terms(results: list[dict]) -> list[dict]:
+def aggregate_terms(results: list[dict], query: str = "") -> list[dict]:
     """Aggregate terms by arabic term (after cleaning it)."""
-    # Normalise arabic terms
+    # Flag rows that are an exact match for the query (on any one of their
+    # possibly multiple translations), so those groups can be bubbled to the
+    # top regardless of how many dictionaries carry a merely-related phrase.
+    # Keyed by object identity rather than mutating `term`, so this internal
+    # flag never leaks into the API response.
+    exact_match_by_id = {id(term): query_matches_term(term, query) for term in results}
+
+    # Normalise arabic terms. A single field may pack several synonymous
+    # spellings/terms (see split_translations); each part is a grouping
+    # candidate, and any two rows sharing a part end up in the same group.
     results_with_arabic = [term for term in results if "arabic" in term]
 
+    variants_by_id = {}
     for term in results_with_arabic:
-        term["arabic_normalised"] = normalise_arabic(term["arabic"])
+        variants = [
+            v
+            for v in (
+                normalise_arabic(part) for part in split_translations(term["arabic"])
+            )
+            if v
+        ]
+        variants_by_id[id(term)] = variants or [normalise_arabic(term["arabic"])]
+
+    # Union-find over normalised arabic variants: any two terms sharing a
+    # variant end up in the same connected component/group.
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        root_a, root_b = find(a), find(b)
+        if root_a != root_b:
+            parent[root_a] = root_b
+
+    for term in results_with_arabic:
+        variants = variants_by_id[id(term)]
+        for variant in variants[1:]:
+            union(variants[0], variant)
 
     groups_dict = dict()
     for term in results_with_arabic:
-        arabic_normalised = term["arabic_normalised"]
-        if arabic_normalised not in groups_dict:
-            groups_dict[arabic_normalised] = []
-        groups_dict[arabic_normalised].append(term)
+        key = find(variants_by_id[id(term)][0])
+        groups_dict.setdefault(key, []).append(term)
 
     groups = [
         {"arabic_normalised": key, "occurences": value}
@@ -357,9 +454,16 @@ def aggregate_terms(results: list[dict]) -> list[dict]:
             variant["relevance"] for variant in group["occurences"]
         )
 
-    # Sort by: number of unique dictionaries, then total relevance:
+    # Sort by: exact match first (a group where some occurrence's translation
+    # exactly equals the query), then number of unique dictionaries, then
+    # total relevance.
     groups.sort(
-        key=lambda x: (len(x["dictionary_ids"]), x["total_relevance"]), reverse=True
+        key=lambda x: (
+            any(exact_match_by_id[id(term)] for term in x["occurences"]),
+            len(x["dictionary_ids"]),
+            x["total_relevance"],
+        ),
+        reverse=True,
     )
     return groups
 
@@ -473,7 +577,7 @@ def search(
     summary="Search results aggregated by normalised Arabic term",
     response_model=AggregatedSearchResponse,
     response_model_exclude_none=True,
-    response_description="Term groups, ordered by number of distinct dictionaries (desc), then by total relevance (desc).",
+    response_description="Term groups, exact matches for the query first, then ordered by number of distinct dictionaries (desc), then by total relevance (desc).",
 )
 def search_aggregated(
     q: str = Query(
@@ -489,17 +593,24 @@ def search_aggregated(
     """Search and group results by normalised Arabic term.
 
     Raw matches are clustered by `normalise_arabic(arabic)` (diacritics, tatweel
-    and the `ال` prefix stripped, hamza forms unified). Each group elects the
-    most common original Arabic spelling, the most common normalised English
-    translation, and — when present — the most common normalised French
-    translation. Within a group, occurrences are ordered by dictionary type
-    (`terminology`, then `language`, then `thesaurus`; unclassified last),
-    then by `tier` ascending (1 = most reliable), then bubbling entries
-    without a Wikidata ID to the end.
+    and the `ال` prefix stripped, hamza forms unified). A field packing several
+    synonymous translations (separated by `;`, `/`, or the Arabic `،` / `؛`) is
+    split into its parts first, so e.g. an Arabic field of `"تلسكوب، مقراب"`
+    joins the groups for both `تلسكوب` and `مقراب` instead of forming an
+    isolated group of its own. Each group elects the most common original
+    Arabic spelling, the most common normalised English translation, and —
+    when present — the most common normalised French translation. Within a
+    group, occurrences are ordered by dictionary type (`terminology`, then
+    `language`, then `thesaurus`; unclassified last), then by `tier` ascending
+    (1 = most reliable), then bubbling entries without a Wikidata ID to the
+    end.
 
-    Groups are sorted by the number of distinct dictionaries that contain the
-    term (desc), then by the sum of relevance scores within the group (desc).
-    This is the endpoint used by the on-wiki gadget.
+    Groups are sorted with exact matches first — a group where some
+    occurrence's Arabic/English/French translation (or one part of a
+    multi-translation field) equals the query exactly — then by the number of
+    distinct dictionaries that contain the term (desc), then by the sum of
+    relevance scores within the group (desc). This is the endpoint used by
+    the on-wiki gadget.
     """
     sentry_sdk.set_tag("search.q", q[:200])  # Sentry caps tag values at 200 chars
 
@@ -511,7 +622,7 @@ def search_aggregated(
             if "uri" in result and "arabterm.org" in result["uri"]:
                 del result["uri"]
 
-    groups = aggregate_terms(results)
+    groups = aggregate_terms(results, q)
     number_groups = len(groups)
 
     sentry_sdk.set_tag("search.number_groups", str(number_groups))

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,5 +1,12 @@
 import pytest
-from app import aggregate_terms, normalise_arabic, normalise_english, normalise_french
+from app import (
+    aggregate_terms,
+    normalise_arabic,
+    normalise_english,
+    normalise_french,
+    query_matches_term,
+    split_translations,
+)
 
 
 @pytest.mark.parametrize(
@@ -259,3 +266,110 @@ def test_aggregate_terms_orders_occurences_by_dict_type_then_tier():
     )
 
     assert [o["dictionary_id"] for o in groups[0]["occurences"]] == [4, 3, 2, 1, 5]
+
+
+@pytest.mark.parametrize(
+    "input_text, expected_output",
+    [
+        ("تلسكوب، مِقْراب", ["تلسكوب", "مِقْراب"]),
+        ("مُشترِك، مستهلِك، مستعمِل", ["مُشترِك", "مستهلِك", "مستعمِل"]),
+        ("مِقراب؛ راصدة", ["مِقراب", "راصدة"]),
+        ("landslide; landslip", ["landslide", "landslip"]),
+        ("ordinateur; calculatrice", ["ordinateur", "calculatrice"]),
+        ("container/dumpster", ["container", "dumpster"]),
+        ("  a  ;  b  /c", ["a", "b", "c"]),
+        ("مقراب", ["مقراب"]),
+        # A plain ',' is NOT a separator: this dataset also uses it for
+        # headword inversion ("profile, hydraulic") and gender/POS
+        # annotations ("vitesse commerciale, f"), so splitting on it would
+        # fabricate bogus translations.
+        ("profile, hydraulic", ["profile, hydraulic"]),
+    ],
+)
+def test_split_translations(input_text, expected_output):
+    assert split_translations(input_text) == expected_output
+
+
+def test_query_matches_term_exact_arabic_part():
+    term = {"arabic": "تلسكوب، مِقْراب", "english": "telescope"}
+    assert query_matches_term(term, "مقراب") is True
+    assert query_matches_term(term, "تلسكوب") is True
+    assert query_matches_term(term, "مرصد") is False
+
+
+def test_query_matches_term_exact_translation_part_case_insensitive():
+    term = {
+        "arabic": "انزلاق التربة",
+        "english": "landslide; landslip",
+        "french": "éboulement",
+    }
+    assert query_matches_term(term, "Landslide") is True
+    assert query_matches_term(term, "landslip") is True
+    assert query_matches_term(term, "landslides") is False
+
+
+def test_query_matches_term_strips_quoted_query():
+    # The frontend and gadget both send q=`"${term}"` (literal quotes).
+    term = {"english": "telescope"}
+    assert query_matches_term(term, '"telescope"') is True
+
+
+def test_query_matches_term_not_fooled_by_compound_phrase():
+    term = {"english": "reflecting telescope"}
+    assert query_matches_term(term, "telescope") is False
+
+
+def test_query_matches_term_empty_query():
+    assert query_matches_term({"english": "telescope"}, "") is False
+
+
+def test_aggregate_terms_merges_rows_via_separator_packed_translations():
+    # id=140327-like row: a plain, single-spelling entry.
+    plain_telescope = {
+        "arabic": "مقراب",
+        "english": "telescope",
+        "dictionary_id": 1,
+        "relevance": 1.0,
+    }
+    # id=208889: packs two synonymous Arabic spellings in one field, one of
+    # which ("مقراب") matches the plain entry above.
+    packed = {
+        "arabic": "تلسكوب، مِقْراب",
+        "english": "telescope",
+        "dictionary_id": 2,
+        "relevance": 1.0,
+    }
+    groups = aggregate_terms([plain_telescope, packed])
+
+    assert len(groups) == 1
+    assert groups[0]["dictionary_ids"] == [1, 2]
+    assert {o["dictionary_id"] for o in groups[0]["occurences"]} == {1, 2}
+
+
+def test_aggregate_terms_bubbles_exact_match_to_top():
+    # id=134457-like: a single-dictionary exact match for "telescope".
+    exact_match = {
+        "arabic": "مرقب",
+        "english": "telescope",
+        "dictionary_id": 1,
+        "relevance": 10.0,
+    }
+    # A compound phrase spread across two dictionaries -- more supporting
+    # dictionaries than the exact match, but not itself an exact match.
+    compound_a = {
+        "arabic": "مقراب عاكس",
+        "english": "reflecting telescope",
+        "dictionary_id": 2,
+        "relevance": 10.0,
+    }
+    compound_b = {
+        "arabic": "مقراب عاكس",
+        "english": "reflecting telescope",
+        "dictionary_id": 3,
+        "relevance": 10.0,
+    }
+
+    groups = aggregate_terms([exact_match, compound_a, compound_b], "telescope")
+
+    assert groups[0]["arabic_normalised"] == "مرقب"
+    assert groups[1]["arabic_normalised"] == "مقراب عاكس"


### PR DESCRIPTION
## Summary

Two search-quality fixes for `/api/v1/search/aggregated`, reported against the "telescope" query:

- **Exact matches sorted far down.** MariaDB's `NATURAL LANGUAGE MODE` scores "telescope" and "reflecting telescope" identically, so tie-breaking was arbitrary and groups like مرقب / مقراب / مرصد (all exactly "telescope") ended up far below compound-phrase matches. `aggregate_terms` now sorts exact matches first, before dictionary count / relevance.
- **Separator-packed translations isolated from their peers.** Entries like `تلسكوب، مِقْراب` (id 208889) or `مِقراب؛ راصدة` (id 504832) pack multiple synonymous translations into one field, so they formed their own lonely group instead of joining `مقراب`. These are now split on `;`, `/`, `،`, `؛` and merged into their peers' groups via union-find. Deliberately **not** splitting on plain `,` — this dataset also uses it for headword inversion (`"profile, hydraulic"`) and gender/POS annotations (`"vitesse commerciale, f"`), confirmed by sampling the actual data.

Verified against the local DB: searching "telescope" now returns مقراب (merged, 3 dictionaries), منظار, مرقب, مرصد as the top 4 groups, all before any compound-phrase match — previously مرقب and مرصد were ranked 5th and 11th.

Minor incidental cleanup: occurrences no longer carry a stray unused `arabic_normalised` field per-occurrence in the JSON response (confirmed unused by both the React app and the gadget).

## Test plan
- [x] `make test` — 30 passed (12 new tests covering `split_translations`, `query_matches_term`, and the merge/ranking behavior in `aggregate_terms`)
- [x] `make check` / `make format` clean
- [x] Manually verified against local DB via a running dev server for `telescope`, `user`, `landslide`, and `calculatrice` queries