### PR TITLE
Don't transitively merge groups via separator-packed translations

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -365,51 +365,47 @@ def aggregate_terms(results: list[dict], query: str = "") -> list[dict]:
     exact_match_by_id = {id(term): query_matches_term(term, query) for term in results}
 
     # Normalise arabic terms. A single field may pack several synonymous
-    # spellings/terms (see split_translations); each part is a grouping
-    # candidate, and any two rows sharing a part end up in the same group.
+    # spellings/terms (see split_translations); each part independently
+    # looks for (or starts) its own group by exact normalised match. A
+    # packed row therefore contributes a separate virtual occurrence to
+    # every group its parts belong to -- e.g. "مِقراب؛ راصدة" adds one
+    # occurrence to the (pre-existing) "مقراب" group and another to a
+    # standalone "راصدة" group, without merging those two groups together.
     results_with_arabic = [term for term in results if "arabic" in term]
 
-    variants_by_id = {}
+    # For each term: list of (normalised_variant, raw_part) pairs, one per
+    # distinct part of its arabic field (deduplicated, order preserved).
+    memberships_by_id = {}
     for term in results_with_arabic:
-        variants = [
-            v
-            for v in (
-                normalise_arabic(part) for part in split_translations(term["arabic"])
-            )
-            if v
+        seen_variants = set()
+        pairs = []
+        for raw_part in split_translations(term["arabic"]):
+            variant = normalise_arabic(raw_part)
+            if variant and variant not in seen_variants:
+                seen_variants.add(variant)
+                pairs.append((variant, raw_part))
+        memberships_by_id[id(term)] = pairs or [
+            (normalise_arabic(term["arabic"]), term["arabic"])
         ]
-        variants_by_id[id(term)] = variants or [normalise_arabic(term["arabic"])]
 
-    # Union-find over normalised arabic variants: any two terms sharing a
-    # variant end up in the same connected component/group.
-    parent = {}
-
-    def find(x):
-        parent.setdefault(x, x)
-        while parent[x] != x:
-            parent[x] = parent[parent[x]]
-            x = parent[x]
-        return x
-
-    def union(a, b):
-        root_a, root_b = find(a), find(b)
-        if root_a != root_b:
-            parent[root_a] = root_b
-
-    for term in results_with_arabic:
-        variants = variants_by_id[id(term)]
-        for variant in variants[1:]:
-            union(variants[0], variant)
-
+    # variant -> list of (term, raw_part) contributed by that variant.
     groups_dict = dict()
     for term in results_with_arabic:
-        key = find(variants_by_id[id(term)][0])
-        groups_dict.setdefault(key, []).append(term)
+        for variant, raw_part in memberships_by_id[id(term)]:
+            groups_dict.setdefault(variant, []).append((term, raw_part))
 
-    groups = [
-        {"arabic_normalised": key, "occurences": value}
-        for key, value in groups_dict.items()
-    ]
+    groups = []
+    for entries in groups_dict.values():
+        raw_parts = [raw_part for _term, raw_part in entries]
+        groups.append(
+            {
+                # Elect the raw (unnormalised) spelling used most often to
+                # reach this group, so a packed field like "تلسكوب، مِقْراب"
+                # doesn't become the displayed headline for either group.
+                "arabic_normalised": Counter(raw_parts).most_common(1)[0][0],
+                "occurences": [term for term, _raw_part in entries],
+            }
+        )
 
     # Add terms without arabic as separate groups with one occurence
     results_without_arabic = [term for term in results if "arabic" not in term]
@@ -425,12 +421,6 @@ def aggregate_terms(results: list[dict], query: str = "") -> list[dict]:
         # Attention: we assume all entries have an english term.
         english_terms = [normalise_english(x["english"]) for x in group["occurences"]]
         group["english_normalised"] = Counter(english_terms).most_common(1)[0][0]
-
-        # Change arabic_normalised by electing it from existing occurences.
-        # The original arabic_normalised is useful for groupping, but sometimes produces incorrect terms.
-        if "arabic_normalised" in group:
-            arabic_terms = [x["arabic"] for x in group["occurences"]]
-            group["arabic_normalised"] = Counter(arabic_terms).most_common(1)[0][0]
 
         # Elect a french term (normalised) among entries with french.
         french_terms = [
@@ -595,15 +585,17 @@ def search_aggregated(
     Raw matches are clustered by `normalise_arabic(arabic)` (diacritics, tatweel
     and the `ال` prefix stripped, hamza forms unified). A field packing several
     synonymous translations (separated by `;`, `/`, or the Arabic `،` / `؛`) is
-    split into its parts first, so e.g. an Arabic field of `"تلسكوب، مقراب"`
-    joins the groups for both `تلسكوب` and `مقراب` instead of forming an
-    isolated group of its own. Each group elects the most common original
-    Arabic spelling, the most common normalised English translation, and —
-    when present — the most common normalised French translation. Within a
-    group, occurrences are ordered by dictionary type (`terminology`, then
-    `language`, then `thesaurus`; unclassified last), then by `tier` ascending
-    (1 = most reliable), then bubbling entries without a Wikidata ID to the
-    end.
+    split into its parts first, and each part independently joins (or starts)
+    its own group by exact normalised match — e.g. an Arabic field of
+    `"مِقراب؛ راصدة"` contributes a virtual occurrence to the (pre-existing)
+    `مقراب` group and another to a standalone `راصدة` group, without merging
+    those two groups together. Each group elects the most common original
+    Arabic spelling among the parts that reached it, the most common
+    normalised English translation, and — when present — the most common
+    normalised French translation. Within a group, occurrences are ordered by
+    dictionary type (`terminology`, then `language`, then `thesaurus`;
+    unclassified last), then by `tier` ascending (1 = most reliable), then
+    bubbling entries without a Wikidata ID to the end.
 
     Groups are sorted with exact matches first — a group where some
     occurrence's Arabic/English/French translation (or one part of a

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -323,7 +323,7 @@ def test_query_matches_term_empty_query():
     assert query_matches_term({"english": "telescope"}, "") is False
 
 
-def test_aggregate_terms_merges_rows_via_separator_packed_translations():
+def test_aggregate_terms_packed_row_joins_each_variants_group_separately():
     # id=140327-like row: a plain, single-spelling entry.
     plain_telescope = {
         "arabic": "مقراب",
@@ -331,19 +331,58 @@ def test_aggregate_terms_merges_rows_via_separator_packed_translations():
         "dictionary_id": 1,
         "relevance": 1.0,
     }
-    # id=208889: packs two synonymous Arabic spellings in one field, one of
-    # which ("مقراب") matches the plain entry above.
+    # id=504832-like: packs two synonymous Arabic spellings in one field.
+    # "مِقراب" should join the group above; "راصدة" has no other entry
+    # anywhere, but still gets its own (single-occurrence) group rather
+    # than being folded into "مقراب"'s.
     packed = {
-        "arabic": "تلسكوب، مِقْراب",
+        "arabic": "مِقراب؛ راصدة",
         "english": "telescope",
         "dictionary_id": 2,
         "relevance": 1.0,
     }
     groups = aggregate_terms([plain_telescope, packed])
+    groups_by_key = {g["arabic_normalised"]: g for g in groups}
 
-    assert len(groups) == 1
-    assert groups[0]["dictionary_ids"] == [1, 2]
-    assert {o["dictionary_id"] for o in groups[0]["occurences"]} == {1, 2}
+    assert set(groups_by_key) == {"مقراب", "راصدة"}
+
+    miqrab_group = groups_by_key["مقراب"]
+    assert miqrab_group["dictionary_ids"] == [1, 2]
+    assert {o["dictionary_id"] for o in miqrab_group["occurences"]} == {1, 2}
+
+    rasida_group = groups_by_key["راصدة"]
+    assert rasida_group["dictionary_ids"] == [2]
+    # The virtual occurrence still shows the full, original citation.
+    assert rasida_group["occurences"][0]["arabic"] == "مِقراب؛ راصدة"
+
+
+def test_aggregate_terms_does_not_transitively_merge_unrelated_groups():
+    # A row bundling two variants must NOT fuse those two variants' groups
+    # into one -- each variant's group stays independent.
+    hub = {
+        "arabic": "أ؛ ب",
+        "english": "hub",
+        "dictionary_id": 1,
+        "relevance": 1.0,
+    }
+    only_a = {
+        "arabic": "أ",
+        "english": "only a",
+        "dictionary_id": 2,
+        "relevance": 1.0,
+    }
+    only_b = {
+        "arabic": "ب",
+        "english": "only b",
+        "dictionary_id": 3,
+        "relevance": 1.0,
+    }
+    groups = aggregate_terms([hub, only_a, only_b])
+    groups_by_key = {g["arabic_normalised"]: g for g in groups}
+
+    assert set(groups_by_key) == {"أ", "ب"}
+    assert {o["dictionary_id"] for o in groups_by_key["أ"]["occurences"]} == {1, 2}
+    assert {o["dictionary_id"] for o in groups_by_key["ب"]["occurences"]} == {1, 3}
 
 
 def test_aggregate_terms_bubbles_exact_match_to_top():


### PR DESCRIPTION
## Summary

Follow-up to #68. That PR merged all variants listed in a packed field (e.g. `مِقراب؛ راصدة`) into a single group via union-find. Feedback on the shipped behavior: a variant with no independent support elsewhere (like `راصدة`) never got its own group — it was always folded into whichever variant had more support (`مقراب`). That's also a latent risk: a row loosely bundling two words could chain-merge two otherwise-unrelated existing groups together through a shared term.

This replaces the union-find merge with **per-variant group membership**: each split part of a packed field independently looks for (or starts) its own group by exact normalised match. A packed row now contributes a separate *virtual* occurrence to every group its parts belong to, instead of fusing those groups into one.

Concretely, for `مِقراب؛ راصدة` (id 504832):
- one virtual occurrence joins the existing `مقراب` group (merging with id=140327 etc., same as before)
- another virtual occurrence forms its own standalone `راصدة` group — even though no other row has `راصدة` alone

The occurrence itself still shows the full original citation (`"مِقراب؛ راصدة"`) for transparency; only the group's elected headline differs per group.

Verified against the local DB: searching "telescope" now surfaces `تلسكوب` and `راصدة` as their own groups (previously absorbed into `مقراب`), while `مقراب` itself still correctly aggregates support from all three contributing dictionaries.

## Test plan
- [x] `make test` — 31 passed (updated the merge test to reflect independent-group semantics, added a test asserting two unrelated groups are never transitively fused via a shared "hub" row)
- [x] `make check` / `make format` clean
- [x] Manually verified against local DB via a running dev server for the "telescope" query